### PR TITLE
#5 注文履歴

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -2,4 +2,11 @@ class OrdersController < ApplicationController
   def show
     @order = Order.find_by(id: params[:id])
   end
+
+  def index
+    @orders = current_user.orders.page(params[:page]).per(15).order(id: :DESC)
+    page = (params[:page] || 1).to_i
+    par_page = 15
+    @page_adj = (page - 1) * par_page + 1 # ページネーション機能の２ページ目以降のNo.調整
+  end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -4,9 +4,6 @@ class OrdersController < ApplicationController
   end
 
   def index
-    @orders = current_user.orders.page(params[:page]).per(15).order(id: :DESC)
-    page = (params[:page] || 1).to_i
-    par_page = 15
-    @page_adj = (page - 1) * par_page + 1 # ページネーション機能の２ページ目以降のNo.調整
+    @orders = current_user.orders.page(params[:page]).per(15).order(order_date: :DESC)
   end
 end

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,0 +1,54 @@
+<main>
+  <div class="container">
+    <% if @orders.any? %>
+      <table class="table mt-5">
+        <thead class="table-sm h4">
+          <tr>
+            <th class="text-left" width="5%">No</th>
+            <th class="text-left" width="20%">注文番号</th>
+            <th class="text-left" width="40%">お届け先</th>
+            <th class="text-left" width="25%">備考</th>
+            <th class="text-left border-0" width="20%"></th>
+          </tr>
+        </thead>
+        <tbody class="h6 font-weight-normal">
+          <% @orders.each.with_index do |order, i| %>
+            <tr>
+              <th scope="row" class="font-weight-normal"><%= @page_adj + i %></th>
+              <td class="text-left"><%= order.order_number %></td>
+              <td class="text-left">
+                〒<%= order.user.zipcode %><br>
+                <%= order.user.prefecture %> <%= order.user.municipality %> <%= order.user.address %> <%= order.user.apartments %><br>
+                <%= order.user.first_name %> <%= order.user.last_name %> 様
+              </td>
+              <td class="text-left">
+                <%= order.order_date %><br>
+                <p>注文状態：
+                  <% if order.shipment_prepared? %>
+                    準備中
+                  <% else %>
+                    発送済
+                  <% end %>
+                </p>
+              </td>
+              <td class="border-0 align-middle">
+                <%= link_to "詳細", order_path(order.id), class: "btn btn-primary btn-sm" %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+      <div class="container">
+        <%= paginate @orders %>
+      </div>
+    <% else %>
+    <div class="container">
+      <div class="jumbotron text-center bg-white"></div>
+        <div class="mt-5 text-center">
+          <h1>注文履歴は存在しません</h1>
+        </div>
+      </div>
+    </div>
+    <% end %>
+  </div>
+</main>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -12,9 +12,9 @@
           </tr>
         </thead>
         <tbody class="h6 font-weight-normal">
-          <% @orders.each.with_index do |order, i| %>
+          <% @orders.each.with_index(1) do |order, i| %>
             <tr>
-              <th scope="row" class="font-weight-normal"><%= @page_adj + i %></th>
+              <th scope="row" class="font-weight-normal"><%= @orders.offset_value + i %></th>
               <td class="text-left"><%= order.order_number %></td>
               <td class="text-left">
                 〒<%= order.user.zipcode %><br>


### PR DESCRIPTION
## このプルリクエストで何をしたのか
注文履歴画面と機能の実装

## 対象issue
- 作業したissueのURLをここに貼ること
- https://github.com/quest-academia/qa-rails-ec-training-rose/issues/5

## 重点的に見てほしいところ(不安なところ)
- ページネーション機能の２ページ目以降のNo.調整をindexコントローラー内で行なっております。
- チケットの説明の参考モックアップに`order_history_no_exit.html`と記載がありましたが、画面定義書の内容に従い、
注文履歴が存在しなかった場合の画面実装を行なっております。

## 実装できなくて後回しにしたところ

## 解決できなかったrubocop指摘

## チェックリスト
- [x] 動作確認は実行した?
- [x] rubocopは実行した?

## その他参考情報
- 実装する上で参考にしたサイトなどがあればリンクをここに貼ること
- kaminariの実装について　https://qiita.com/you8/items/df68aaee3010e282d1ae
- Orderのデータ取得について　https://qiita.com/tobita0000/items/866de191635e6d74e392
