### PR TITLE
#9 ユーザー情報登録ページ、登録処理

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,22 @@ class UsersController < ApplicationController
   before_action :logged_in_user, only: %i[show edit]
   before_action :correct_user, only: %i[show edit]
 
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    @user.user_classification_id = 1 # ユーザー種別を購入者に限定する
+    if @user.save
+      flash[:success] = "ユーザーを登録しました。こちらからログインしてください。"
+      redirect_to login_path
+    else
+      flash[:danger] = "ユーザー情報を登録できませんでした。"
+      render "new"
+    end
+  end
+
   def show
     @user = User.find_by(id: params[:id])
   end
@@ -25,6 +41,6 @@ class UsersController < ApplicationController
 
     def user_params
       params.require(:user).permit(:password, :password_confirmation, :last_name, :first_name, :zipcode, :prefecture, :municipality, :address, :apartments,
-                                   :email, :phone_number)
+                                   :email, :phone_number, :company_name)
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -41,6 +41,6 @@ class UsersController < ApplicationController
 
     def user_params
       params.require(:user).permit(:password, :password_confirmation, :last_name, :first_name, :zipcode, :prefecture, :municipality, :address, :apartments,
-                                   :email, :phone_number, :company_name)
+                                   :email, :phone_number)
     end
 end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -15,7 +15,7 @@
     </div>
 
     <div class="d-flex justify-content-center">
-      <a href="">まだ登録がお済みでない方はこちら</a>
+      <%= link_to "まだ登録がお済みでない方はこちら", signup_path, style: "padding-top: 10px" %>
     </div>
   </div>
 </main>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,92 @@
+<div class="container">
+  <div class="jumbotron text-center bg-white">
+      <h2>お客様情報登録</h2>
+  </div>
+  <div class="row mb-5 ml-5">
+    <div class="col-sm-6 offset-sm-3">
+      <%= form_with model: @user, local: true do |form| %>
+        <%= render 'shared/error_messages', object: form.object %>
+        <div class="row mt-5">
+          <div class="form-group">
+            <p>氏名</p>
+            <div class="row">
+              <div class="col-md-4">
+                <%= form.label :last_name, "姓", class: "mt-2 ml-3" %>
+                <%= form.text_field :last_name, class: "form-control", id: "last_name", maxlength: 10 %>
+              </div>
+              <div class="col-md-4">
+                <%= form.label :first_name, "名", class: "mt-2 ml-3" %>
+                <%= form.text_field :first_name, class: "form-control", id: "first_name", maxlength: 10 %>
+              </div>
+            </div>
+          </div>
+          <div class="form-group">
+            <%= form.label :zipcode, "郵便番号" %>
+          <div class="col-sm-6">
+              <%= form.text_field :zipcode, class: "form-control", id: "zipcode", length: 7 %>
+            </div>
+          </div>
+          <div class="form-group">
+            <p class="mb-1">住所</p>
+            <div class="row">
+              <%= form.label :prefecture, "都道府県", class: "mt-2 ml-4" %>
+              <div class="col-sm-9 mt-1">
+                <%= form.text_field :prefecture, class: "form-control", id: "prefecture", maxlength: 5 %>
+              </div>
+            </div>
+            <div class="row">
+              <%= form.label :municipality, "市町村区", class: "ml-4 mt-2" %>
+              <div class="col-sm-9 mt-1">
+                <%= form.text_field :municipality, class: "form-control", id: "municipality", maxlength: 10 %>
+              </div>
+            </div>
+            <div class="row">
+              <%= form.label :address, "番地", class: "mt-2 ml-4 mr-2" %>
+              <div class="col-sm-9 ml-4 mt-1">
+                <%= form.text_field :address, class: "form-control", id: "address", maxlength: 15 %>
+              </div>
+            </div>
+          </div>
+          <div class="form-group">
+            <%= form.label :apartments, "マンション・部屋番号", class: "ml-2" %>
+            <div class="ml-5 mr-5">
+              <%= form.text_field :apartments, class: "form-control", id: "apartments", maxlength: 20 %>
+            </div>
+          </div>
+          <div class="form-group">
+          <%= form.label :email, "メールアドレス" %>
+            <div class="ml-3 mr-5">
+              <%= form.email_field :email, class: "form-control", id: "email" %>
+            </div>
+          </div>
+          <div class="form-group">
+          <%= form.label :phone_number, "電話番号" %>
+            <div class="ml-3 mr-5">
+              <%= form.text_field :phone_number, class: "form-control", id: "phone_number", maxlength: 15 %>
+            </div>
+          </div>
+          <div class="form-group">
+          <%= form.label :password, "パスワード" %>
+            <div class="col-sm-8">
+              <%= form.password_field :password, class: "form-control", id: "password", minlength: 6, maxlength: 15 %>
+            </div>
+          </div>
+          <div class="form-group">
+          <%= form.label :password_confirmation, "パスワード再入力" %>
+            <div class="col-sm-8">
+              <%= form.password_field :password_confirmation, class: "form-control", id: "password",  minlength: 6, maxlength: 15 %>
+            </div>
+          </div>
+          <div class="row justify-content-center">
+            <div class="col-sm-2 mt-5">
+              <p><%= form.submit "登録", class: "btn btn-primary btn-sm btn-block" %></p>
+            </div>
+          </div>
+          <div class="d-flex justify-content-center">
+            <p><h3><%= link_to "ログインはこちらから", login_path %></h3></P>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   get  'login',   to: 'sessions#new'
   post 'login', to: 'sessions#create'
   delete 'logout', to: 'sessions#destroy'
+  get 'signup', to: 'users#new'
   resources :products
   resources :users
   resources :orders


### PR DESCRIPTION
## このプルリクエストで何をしたのか
ユーザー情報登録ページ、登録処理機能の実装

## 対象issue
- 作業したissueのURLをここに貼ること
https://github.com/quest-academia/qa-rails-ec-training-rose/issues/9
## 重点的に見てほしいところ(不安なところ)
ユーザー種別を購入者に限定するため`@user.user_classification_id = 1`　としました。
## 実装できなくて後回しにしたところ

## 解決できなかったrubocop指摘

## チェックリスト
- [x] 動作確認は実行した?
- [x] rubocopは実行した?

## その他参考情報
- 実装する上で参考にしたサイトなどがあればリンクをここに貼ること
https://railstutorial.jp/chapters/sign_up?version=5.1#cha-sign_up